### PR TITLE
Fix and tweaks on some-options example

### DIFF
--- a/some-options/manifest.json
+++ b/some-options/manifest.json
@@ -9,6 +9,7 @@
       "page": "options.html",
       "chrome_style": true
   },
+  "permissions": ["storage"],
   "description": "An example options ui",
   "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/tabs-tabs-tabs",
   "manifest_version": 2,

--- a/some-options/options.js
+++ b/some-options/options.js
@@ -1,9 +1,14 @@
 function save_options(e) {
+  chrome.storage.local.set({
+    colour: document.querySelector("#colour").value
+  });
 }
 
-
 function restore_options() {
-  chrome.storage.local.get('colour');
+  chrome.storage.local.get('colour', (res) => {
+    document.querySelector("#colour").value = res.colour;
+  });
 }
 
 document.addEventListener('DOMContentLoaded', restore_options);
+document.querySelector("form").addEventListener("submit", save_options);


### PR DESCRIPTION
This PR applies a couple of fixes and tweaks on the upcoming some-options example:

- add storage permission to the manifest.json (or the storage API will not be available in the options UI page)
- tweak options.js script to test that the API is working (e.g. add a callback to chrome.storage.get to get the query result and restore it on load, save to the storage on submit)